### PR TITLE
Update python version for conda-flask-api

### DIFF
--- a/docker/conda-flask-api/environment.yml
+++ b/docker/conda-flask-api/environment.yml
@@ -2,6 +2,6 @@ name: base
 channels:
 - defaults
 dependencies:
-- python=3.7
+- python=3.12
 - flask
 - gunicorn


### PR DESCRIPTION
Conda can't resolve a dependency on conda-anaconda-telemetry at 3.7